### PR TITLE
Fix Windows path handling for deployment and config loading

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Plugin } from './plugin.js';
 import { loadConfig } from './utils.js';
 
@@ -58,6 +59,6 @@ export async function loadDeploymentZipConfig(configFilePath: string): Promise<C
 }
 
 export async function loadPackageJSON(): Promise<Record<string, any>> {
-  const __dirname = new URL('.', import.meta.url).pathname;
+  const __dirname = fileURLToPath(new URL('.', import.meta.url));
   return JSON.parse(await readFile(resolve(__dirname, '../package.json'), 'utf-8'));
 }

--- a/src/deploy/common.ts
+++ b/src/deploy/common.ts
@@ -1,6 +1,7 @@
 import { createReadStream } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { relative } from 'node:path';
+import { relative, sep } from 'node:path';
+import { sep as posixSep } from 'node:path/posix';
 import { Readable } from 'node:stream';
 import { consola } from 'consola';
 import { colorize } from 'consola/utils';
@@ -79,13 +80,14 @@ export async function eachDeployFiles(
 
   const taskFunc = async (file: string) => {
     const relativePath = relative(inputDir, file);
-    if (ig.ignores(relativePath)) {
-      consola.log(colorize('gray', `skip ${relativePath}`));
+    const normalizedRelativePath = relativePath.split(sep).join(posixSep);
+    if (ig.ignores(normalizedRelativePath)) {
+      consola.log(colorize('gray', `skip ${normalizedRelativePath}`));
     } else {
-      consola.log(colorize('green', `add ${relativePath}`));
+      consola.log(colorize('green', `add ${normalizedRelativePath}`));
       await cb({
         file,
-        relativePath,
+        relativePath: normalizedRelativePath,
         inputStream: await buildReadStream({
           inputFile: file,
           config,


### PR DESCRIPTION
### Motivation
- Windows uses backslashes for paths which caused ignore matching, logs, and upstream deploy targets to be incorrect; paths should be normalized to POSIX style for cross-platform correctness.
- Resolving `package.json` via a URL pathname produced Windows-incorrect paths so `fileURLToPath` is needed to get a proper filesystem path on all platforms.

### Description
- Normalize relative file paths to POSIX separators (`/`) before ignore matching, log messages, and handing the `relativePath` to deploy callbacks in `src/deploy/common.ts`.
- Replace URL pathname usage with `fileURLToPath(new URL('.', import.meta.url))` when computing `__dirname` in `src/config.ts` to ensure correct path resolution on Windows.
- Updated logging to print normalized paths so output is consistent across platforms.

### Testing
- Ran `pnpm test` which executed the test suite and all tests passed (1 test file, 6 tests) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022ea80890833298885b01e703ffd8)